### PR TITLE
Added support for Rust 2018, Elixir 1.8 / OTP 21+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@
 
 ## Versions
 
+<<<<<<< HEAD
 * Elixir 1.6
 * OTP 20
 * Rust 1.26.0
 * Rustler 0.16.0
+=======
+* Elixir ~> 1.8
+* OTP 21
+* Rust 2018 ~> 1.32 `(9fda7c223 2019-01-16)`
+* Rustler 1.19.1
+>>>>>>> Added support for Rust 2018, Elixir 1.8 / OTP 21+
 
 ## Build
 
@@ -33,7 +40,11 @@ Add `spirit_fingers` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
+<<<<<<< HEAD
     {:spirit_fingers, "~> 0.1.3"}
+=======
+    {:spirit_fingers, "~> 0.2"}
+>>>>>>> Added support for Rust 2018, Elixir 1.8 / OTP 21+
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule SpiritFingers.MixProject do
   def project do
     [
       app: :spirit_fingers,
-      version: "0.1.3",
-      elixir: "~> 1.6",
+      version: "0.1.2",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "SpiritFingers",
@@ -29,8 +29,8 @@ defmodule SpiritFingers.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:rustler, "~> 0.16.0"},
-      {:ex_doc, "~> 0.18.3", only: :dev, runtime: false},
+      {:rustler, "~> 0.19.1"},
+      {:ex_doc, "~> 0.19.3", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,9 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "rustler": {:hex, :rustler, "0.16.0", "9b04237d2e7b30fcae40a28edb56f59aad8f4e3c8790f4996b5f200f649964be", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.19.1", "5ee93e579a3092a38f9dc55d610368982a50282163449c66a7b9eed94cf56c68", [:mix], [], "hexpm"},
 }

--- a/native/simhash/Cargo.lock
+++ b/native/simhash/Cargo.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "erlang_nif-sys"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8,7 +8,7 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -16,46 +16,43 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.1.16"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "lazy_static"
-version = "0.2.11"
+name = "proc-macro2"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quote"
-version = "0.3.15"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustler"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "erlang_nif-sys 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erlang_nif-sys 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustler_codegen"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "simhash"
-version = "0.1.0"
-dependencies = [
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustler 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustler_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "simhash 0.2.0 (git+https://github.com/holsee/simhash-rs.git)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -63,30 +60,32 @@ name = "simhash"
 version = "0.2.0"
 source = "git+https://github.com/holsee/simhash-rs.git#7fc44d12901beb7c1a3de66e2a83b89cc298dded"
 dependencies = [
- "siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "simhash"
+version = "0.2.0"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustler 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustler_codegen 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simhash 0.2.0 (git+https://github.com/holsee/simhash-rs.git)",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
+version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -96,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -113,18 +112,17 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum erlang_nif-sys 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2804cb6ae339787d993faafdd5e4af5a882128e44343a710d1061c487086eaa3"
-"checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
-"checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rustler 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "346b8e397f17bc25a7a2b2a394fe016547817fe17a7c6849d878f1c6f1e369a2"
-"checksum rustler_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b94e2cb016a43a5e269a5cf76523d00278347f985cf7fbf6062ef026236144d"
+"checksum erlang_nif-sys 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9bc72dbc2c220693a2a009ec97705c144ea5cc5db703df43feb903663c999536"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum rustler 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcfe1f617edafa3ac024db22b114ac9e3f419147513669b603631d7e5ec199c"
+"checksum rustler_codegen 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51de5e9a173398735100094c20035787e7bf71f5f097f9b3422d1d1d33d2ef0a"
 "checksum simhash 0.2.0 (git+https://github.com/holsee/simhash-rs.git)" = "<none>"
-"checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/native/simhash/Cargo.toml
+++ b/native/simhash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simhash"
-version = "0.1.0"
+version = "0.2.0"
 authors = []
 
 [lib]
@@ -9,9 +9,9 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "0.16.0"
-rustler_codegen = "0.16.0"
-lazy_static = "0.2"
+rustler = "0.19.0"
+rustler_codegen = "0.19.0"
+lazy_static = "1.2"
 
 [dependencies.simhash]
 git = "https://github.com/holsee/simhash-rs.git"

--- a/native/simhash/src/lib.rs
+++ b/native/simhash/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate rustler;
 #[macro_use] extern crate lazy_static;
 
-use rustler::{NifEnv, NifTerm, NifResult, NifEncoder};
+use rustler::{Env, Term, NifResult, Encoder};
 
 extern crate simhash;
 
@@ -23,27 +23,27 @@ rustler_export_nifs! {
     None
 }
 
-fn simhash<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+fn simhash<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let text: &str = try!(args[0].decode());
     let hash: u64 = simhash::simhash(text);
     Ok((atoms::ok(), hash).encode(env))
 }
 
-fn hamming_distance<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+fn hamming_distance<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let hash0: u64 = try!(args[0].decode());
     let hash1: u64 = try!(args[1].decode());
     let ham_dist: f64 = simhash::hamming_distance(hash0, hash1) as f64;
     Ok((atoms::ok(), ham_dist).encode(env))
 }
 
-fn hash_similarity<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+fn hash_similarity<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let hash0: u64 = try!(args[0].decode());
     let hash1: u64 = try!(args[1].decode());
     let similarity: f64 = simhash::hash_similarity(hash0, hash1) as f64;
     Ok((atoms::ok(), similarity).encode(env))
 }
 
-fn similarity<'a>(env: NifEnv<'a>, args: &[NifTerm<'a>]) -> NifResult<NifTerm<'a>> {
+fn similarity<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let text0: &str = try!(args[0].decode());
     let text1: &str = try!(args[1].decode());
     let similarity: f64 = simhash::similarity(text0, text1) as f64;


### PR DESCRIPTION
As part of the resolution of: https://github.com/holsee/spirit_fingers/issues/1

I am updating the dependencies:
* Using Rust 2018
* Using Elixir ~> 1.8
* Using Erlang (OTP) 21
* Other minor deps unlocked and updated on elixir and rust sides.

Bumping version to 0.2.0

`Tests Passing`
`Dialyzer Passing`